### PR TITLE
Add workflow to update docs languages pages on locale changes

### DIFF
--- a/.github/scripts/publish-languages-to-docs.js
+++ b/.github/scripts/publish-languages-to-docs.js
@@ -1,0 +1,43 @@
+const fs = require("fs");
+
+const scripts = {};
+for (const entry of fs.readdirSync(".", { withFileTypes: true })) {
+  if (!entry.isDirectory() || !entry.name.startsWith("jg-")) continue;
+  const locales = fs
+    .readdirSync(entry.name)
+    .filter((f) => f.endsWith(".lua"))
+    .map((f) => f.replace(/\.lua$/, ""))
+    .sort();
+  if (locales.length) scripts[entry.name] = locales;
+}
+
+const payload = {
+  event_type: "languages",
+  client_payload: { scripts },
+};
+
+fetch("https://api.github.com/repos/jgscripts/jg-docs/dispatches", {
+  method: "POST",
+  headers: {
+    authorization: `Bearer ${process.env.GH_API_TOKEN}`,
+    accept: "application/vnd.github+json",
+    "user-agent": "jg-translations-workflow",
+  },
+  body: JSON.stringify(payload),
+})
+  .then(async (res) => {
+    if (!res.ok) {
+      console.error("Languages dispatch failed:", res.status, await res.text());
+      process.exit(1);
+    }
+    console.log(
+      "Languages payload dispatched to jgscripts/jg-docs:",
+      Object.entries(scripts)
+        .map(([k, v]) => `${k} (${v.length})`)
+        .join(", ")
+    );
+  })
+  .catch((err) => {
+    console.error("Languages dispatch failed:", err);
+    process.exit(1);
+  });

--- a/.github/workflows/update-docs-languages.yml
+++ b/.github/workflows/update-docs-languages.yml
@@ -1,0 +1,27 @@
+name: Update docs languages pages
+
+# Tells docs.jgscripts.com to regenerate every script's Languages page
+# whenever locale files change on main. Requires the JAMES_PAT secret
+# (same PAT the script repos use for changelog dispatches).
+on:
+  push:
+    branches: [main]
+    paths: ["jg-*/**"]
+  workflow_dispatch:
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Dispatch languages payload to jg-docs
+        env:
+          GH_API_TOKEN: ${{ secrets.JAMES_PAT }}
+        run: node .github/scripts/publish-languages-to-docs.js


### PR DESCRIPTION
Dispatches a repository_dispatch (type: languages) to jgscripts/jg-docs with every script's locale list. The docs repo regenerates each script's Languages page from it. Needs the JAMES_PAT secret.